### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "clang"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # SonicMania43Patcher
 patches Sonic Mania's memory so it'll run at 4:3
+
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/SonicMania43Patcher)](https://repl.it/github/UzayAnil/SonicMania43Patcher)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@UzayAnil/SonicMania43Patcher).